### PR TITLE
Add:投稿した曲をプロフィール画面に表示

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find_by(username: params[:username])
+    @answers = @user.answers.includes(:theme).includes(:likes).order(created_at: :desc)
   end
 
   def new

--- a/app/views/themes/_like.html.erb
+++ b/app/views/themes/_like.html.erb
@@ -5,6 +5,7 @@
                           data: { turbo_method: :post } do %>
                             <svg xmlns="http://www.w3.org/2000/svg" class="mr-2 -ml-1 w-6 h-6" fill="currentColor" viewBox="0 0 16 16"> <path d="m8 2.748-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385.92 1.815 2.834 3.989 6.286 6.357 3.452-2.368 5.365-4.542 6.286-6.357.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01L8 2.748zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143c.06.055.119.112.176.171a3.12 3.12 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15z"></path></svg>
                           <% end %>
-    <div class=""><%= answer.likes.count %></div>
+    <div class=""><%= answer.likes.size %></div>
+    <%# .count メソッドは ActiveRecord::Associations::CollectionProxy にも定義されており、対象のテーブルに COUNT(*) 句のクエリを発行してしまい、N+1問題を引き起こすためsizeメソッドを使用 %>
   </div>
 <% end %>

--- a/app/views/themes/_unlike.html.erb
+++ b/app/views/themes/_unlike.html.erb
@@ -14,6 +14,6 @@
                           data: { turbo_method: :delete } do %>
                             <svg style="color: red" xmlns="http://www.w3.org/2000/svg" class="mr-2 -ml-1 w-6 h-6" fill="currentColor" viewBox="0 0 16 16"> <path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314z"></path></svg>
                           <% end %>
-    <div class=""><%= answer.likes.count %></div>
+    <div class=""><%= answer.likes.size %></div>
   </div>
 <% end %>

--- a/app/views/users/_answer.html.erb
+++ b/app/views/users/_answer.html.erb
@@ -1,0 +1,35 @@
+<div class="">
+  <div class="flex items-center my-2">
+    <%= link_to image_tag(answer.user.avatar.url, class:'rounded-full w-11'), user_path(answer.user.username), {class:"w-11" } %>
+    <%= link_to answer.user.name, user_path(answer.user.username), {class:"ml-2"} %>
+  </div>
+  <div class=" text-xl">
+    <%= link_to "#{answer.theme.title}", theme_path(answer.theme), class:"font-bold"  %>に下記の解答を投稿しました。
+  </div>
+  <iframe class="" style="border-radius:12px"
+          src="https://open.spotify.com/embed/track/<%= answer.answer %>?utm_source=generator" width="100%" height="152" 
+          frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+  <div class="flex justify-center items-center">
+    <% if current_user %><div class="grow"></div><% end %>
+    <% if current_user.nil? %>
+      <%= render 'themes/like', { answer: } %>
+    <% elsif current_user.like?(answer) %>
+      <%= render 'themes/unlike', { answer: } %>
+    <% else %>
+      <%= render 'themes/like', { answer: } %>
+    <% end %>
+    <% if current_user && current_user.own?(answer) %>
+      <div class="grow"></div>
+      <%= button_to theme_answer_path(answer.theme, answer), { method: :delete, form: { data: { turbo_confirm: "本当に削除しますか？" }}} do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-trash" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+          <line x1="4" y1="7" x2="20" y2="7"></line>
+          <line x1="10" y1="11" x2="10" y2="17"></line>
+          <line x1="14" y1="11" x2="14" y2="17"></line>
+          <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12"></path>
+          <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3"></path>
+        </svg>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/_answers.html.erb
+++ b/app/views/users/_answers.html.erb
@@ -1,0 +1,1 @@
+<%= render partial:"answer", collection: answers %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
-<div class="bg-white flex justify-center pt-5 h-screen">
-  <div class="w-3/5 bg-white items-center">
+<div class="bg-white flex flex-col items-center pt-5 mb-20">
+  <div class="lg:w-3/5 bg-white items-center">
     <div class="flex">
       <%= image_tag @user.avatar.url, class: 'rounded-full object-center' %>
       <div class="mt-1 ml-4">
@@ -21,6 +21,12 @@
       <%#= render 'shared/follow_stats', {user: @user} %> 
       <%#= render 'follow_form', {user: @user} if logged_in? %>
     </div>
-    
+  </div>
+  <div class="w-11/12 lg:w-3/5">
+    <% if !@user.answers.empty? %>
+      <%= render partial: "answers" , locals: {answers: @answers} %>
+    <% else %>
+      <div>曲がありません
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
   resources :users, param: :username do
     member do
       get :following, :followers
+      get :themes
+      get :answers
+      get :likes
     end
   end
   resource :profile, only: %i[edit update]


### PR DESCRIPTION
## 概要
投稿した曲一覧をプロフィール画面に表示

before
<img width="1256" alt="Screen Shot 2022-12-30 at 16 48 27" src="https://user-images.githubusercontent.com/96676082/210129847-3bb8d36d-ee31-4b12-937b-17c6ce75bc4c.png">

after
<img width="1325" alt="Screen Shot 2022-12-31 at 16 54 28" src="https://user-images.githubusercontent.com/96676082/210129856-8e58def9-6009-4fb3-94fb-0305e8ead5be.png">
