### PR TITLE
Fix:プロフィールに表示される解答一覧の♡の位置の調整 #7

### DIFF
--- a/app/views/users/_answer.html.erb
+++ b/app/views/users/_answer.html.erb
@@ -10,7 +10,7 @@
           src="https://open.spotify.com/embed/track/<%= answer.answer %>?utm_source=generator" width="100%" height="152" 
           frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
   <div class="flex justify-center items-center">
-    <% if current_user %><div class="grow"></div><% end %>
+    <% if current_user && current_user.own?(answer) %><div class="grow"></div><% end %>
     <% if current_user.nil? %>
       <%= render 'themes/like', { answer: } %>
     <% elsif current_user.like?(answer) %>


### PR DESCRIPTION
## 概要
プロフィールに表示される解答一覧の♡の位置の調整
 before
<img width="1297" alt="Screen Shot 2022-12-31 at 17 06 48" src="https://user-images.githubusercontent.com/96676082/210130149-963c08e1-e31d-4667-977f-9fa8fa3541cd.png">

after
<img width="1325" alt="Screen Shot 2022-12-31 at 16 54 28" src="https://user-images.githubusercontent.com/96676082/210130158-33e9cf20-9bc1-4b9f-9bc1-d74847196c63.png">
