### PR TITLE
Add:プロフィール画面の♡一覧リクエスト時のオートスクロール

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,6 +37,7 @@ class UsersController < ApplicationController
 
   def likes
     @user = User.find_by(username: params[:username])
+    @user_likes = @user.likes.order(created_at: :desc).page(params[:page])
   end
 
   private

--- a/app/views/users/likes.html.erb
+++ b/app/views/users/likes.html.erb
@@ -2,8 +2,13 @@
   <%= render  'profile', user: @user %>
   <div class="w-11/12 lg:w-3/5">
     <% if !@user.likes.empty? %>
-      <%# binding.pry %>
-      <%= render "likes", user_likes:@user.likes, user:@user %>
+      <%# 今のページの`<turbo-frame>` %>
+      <%= turbo_frame_tag "user_likes-#{@user_likes.current_page}" do %>
+        <%# 今のページで取得したuser_likes一覧 %>
+        <%= render "likes", user_likes:@user_likes, user:@user %>
+        <%# 遅延読み込みで次ページを取得する`<turbo-frame>` %>
+        <%= turbo_frame_tag "user_likes-#{@user_likes.next_page}", loading: :lazy, src: path_to_next_page(@user_likes) %>
+      <% end %>
     <% else %>
       いいねした曲がありません
     <% end %>


### PR DESCRIPTION
## 概要
プロフィール画面の♡一覧を無限スクロールできるよう設定。
デフォルトでは１２件まで表示し、スクロールすると次の１２件が出てくるよう設定。
(https://gyazo.com/a9be1d80caf130e9d634426d18c2633a)