### PR TITLE
Fix:解答ボタンの位置修正

### DIFF
--- a/app/views/answers/_answer_menus.html.erb
+++ b/app/views/answers/_answer_menus.html.erb
@@ -1,9 +1,8 @@
-<div class="flex justify-center">
   <% if !my_answer.present? %>
     <%= link_to "この曲で解答する", theme_answers_path(theme, answer: "#{song.id}"), data: { turbo_method: :post },
-        class:"mt-4 mb-1 w-36 border-2 border-black bg-white hover:bg-green-400 text-black rounded-full font-bold py-3 lg:my-8 text-center" %>
+        class:"border border-2 text-sm md:text-m ml-2 md:mr-1 lg:mr-2 xl:mr-3 2xl:mr-4 px-0 lg:px-3 py-0 lg:py-5 border-black bg-white hover:bg-green-400 text-black rounded-full font-bold self-center text-center" %>
+        <%# class:"w-30 border-2 border-black bg-white hover:bg-green-400 text-black rounded-full font-bold py-3 text-center" %>
   <% else %>
     <%= link_to "解答を更新する", theme_answer_path(theme, my_answer, answer: "#{song.id}"), data: { turbo_method: :patch },
-        class:"mt-4 mb-1 w-36 border-2 border-black bg-white hover:bg-red-500 text-black rounded-full font-bold py-3 lg:my-8 text-center"  %>
+        class:"w-36 border-2 border-black bg-white hover:bg-red-500 text-black rounded-full font-bold py-3 lg:my-8 text-center"  %>
   <% end %>
-</div>

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -1,11 +1,11 @@
-<div class="mx-auto container flex flex-col pt-10">
-    <%= form_with url: new_theme_answer_path, method: :get, html: { data: { turbo_frame: "song_search" } } do |form| %>
-    <div class="flex flex-col items-center">
+<div class="mx-auto flex flex-col pt-10">
+  <%= form_with url: new_theme_answer_path, method: :get, html: { data: { turbo_frame: "song_search" } } do |form| %>
+    <div class="flex flex-col items-center w-11/12 md:w-6/10 lg:w-1/2 mx-auto">
       <div class="text-xl md:text-2xl mb-3">曲を検索して解答を投稿する</div>
       <div class="text-sm px-2 md:px-0">曲名でヒットしない場合は「曲名 アーティスト名」で検索して下さい。</div>
       <div class="flex w-full justify-center">
         <%= form.text_field :search, placeholder:"曲名、アーティスト名で検索", autocomplete: 'off',
-            class: "w-11/12 md:w-6/10 lg:w-1/2 mt-2 border-black border-2 rounded py-3 px-3 leading-tight focus:bg-white focus:border-black focus:ring-0 placeholder-gray-800 appearance-none" %>
+            class: "w-full mt-2 border-black border-2 rounded py-3 px-3 leading-tight focus:bg-white focus:border-black focus:ring-0 placeholder-gray-800 appearance-none" %>
         <%= button_tag(type: "submit", class: "mt-2") do %>
           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-search" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
             <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
@@ -18,7 +18,7 @@
   </div>
 </div>
 
-<div class="px-4 md:px-36 lg:px-64 xl:px-80 2xl:px-96">
+<div class="w-11/12 md:w-6/10 lg:w-1/2 mx-auto">
   <%= turbo_frame_tag "song_search" do %>
     <div class="flex flex-col items-center text-center">
       <% if @search_params && !@search_params.empty? %>
@@ -28,8 +28,8 @@
     </div>
     <% if @songs %>
       <% @songs.each do |song| %>
-      <div class="my-4">
-        <iframe class="mb-2" style="border-radius:12px" src="https://open.spotify.com/embed/track/<%= song.id %>?utm_source=generator" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+      <div class="my-4 flex">
+        <iframe class="mb-2 mx-auto" style="border-radius:12px" src="https://open.spotify.com/embed/track/<%= song.id %>?utm_source=generator" width="80%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
         <% if current_user %>
           <% if @theme_genre.empty? %>
             <%= render 'answer_menus', {theme: @theme, my_answer: @my_answer, song: song} %>
@@ -38,7 +38,7 @@
           <% elsif @theme_genre.first != "洋楽" && genre_include?(song.artists.first.genres, @theme_genre) %>
             <%= render 'answer_menus', {theme: @theme, my_answer: @my_answer, song: song} %>
           <% else %>
-            <div class="text-center text-lg font-bold mt-4 mb-1 lg:my-8">この曲はジャンル対象外です</div>
+            <div class="text-center text-lg font-bold">この曲はジャンル対象外です</div>
           <% end %>
         <% end %>
       </div>


### PR DESCRIPTION
## 概要
お題に対して曲を解答する際の、解答ボタンの位置修正
before:
<img width="1594" alt="Screen Shot 2023-01-10 at 10 55 24" src="https://user-images.githubusercontent.com/96676082/211444454-c8031694-1e8e-4724-9a24-198d508d1126.png">

after:
<img width="1070" alt="Screen Shot 2023-01-10 at 10 54 49" src="https://user-images.githubusercontent.com/96676082/211444468-3802b45e-9369-4609-9c9e-eed683b0f554.png">
