### PR TITLE
ユーザープロフィールのURLを修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,14 +9,15 @@ Rails.application.routes.draw do
   post '/guest_login', to: 'user_sessions#guest_login'
   delete 'logout', to: 'user_sessions#destroy'
 
-  resources :users, param: :username do
+  resources :users, param: :username, path: '/' do
     member do
-      get :following, :followers
+      # get :following, :followers
       get :themes
       get :answers
       get :likes
     end
   end
+
   resource :profile, only: %i[edit update]
   resources :relationships, only: %i[create destroy]
   resources :themes do


### PR DESCRIPTION
## 概要
ユーザープロフィールページのURLをusers/:username ➝/:usernameに変更